### PR TITLE
Server disconnect handler

### DIFF
--- a/session/handler.go
+++ b/session/handler.go
@@ -14,6 +14,9 @@ type Handler interface {
 	// HandleServerBoundPacket handles a packet that's sent by the session. ctx.Cancel() may be called to
 	// cancel the packet.
 	HandleServerBoundPacket(ctx *event.Context, pk packet.Packet)
+	// HandleServerDisconnect handles the server connection getting closed. ctx.Cancel() may be called after
+	// transferring the player to cancel disconnecting them.
+	HandleServerDisconnect(ctx *event.Context)
 	// HandleTransfer handles a session being transferred to another server. ctx.Cancel() may be called to
 	// cancel the transfer.
 	HandleTransfer(ctx *event.Context, svr *server.Server)
@@ -35,6 +38,9 @@ func (NopHandler) HandleClientBoundPacket(*event.Context, packet.Packet) {}
 
 // HandleServerBoundPacket ...
 func (NopHandler) HandleServerBoundPacket(*event.Context, packet.Packet) {}
+
+// HandleServerDisconnect ...
+func (NopHandler) HandleServerDisconnect(*event.Context) {}
 
 // HandleTransfer ...
 func (NopHandler) HandleTransfer(*event.Context, *server.Server) {}


### PR DESCRIPTION
This PR;
1. adds a handler for the server connection failures
2. changes `session.transferring` to stay `true` until the new connection is set as `session.serverConn`

These two together allow a custom disconnect handler implementation where a player is transferred to another server if the server they are playing on fails.