### PR TITLE
Fixed package to build (. => examples/main.go)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           mkdir -p $GOPATH/bin
           export PATH=$PATH:$GOPATH/bin
       - name: Build Executable
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o portal_${{ matrix.os }}_${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }} -ldflags="-s -w" -v .
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o portal_${{ matrix.os }}_${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }} -ldflags="-s -w" -v example
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           mkdir -p $GOPATH/bin
           export PATH=$PATH:$GOPATH/bin
       - name: Build Executable
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o portal_${{ matrix.os }}_${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }} -ldflags="-s -w" -v example
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o portal_${{ matrix.os }}_${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }} -ldflags="-s -w" -v examples/main.go
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
The `portal` package cannot be a standalone executive at all, or otherwise:
```
./main: line 1: syntax error near unexpected token `newline'
./main: line 1: `!<arch>'
```